### PR TITLE
TimeTagHelper value bugfix

### DIFF
--- a/src/AspNetCore.Honeypot/TagHelpers/HoneypotTimeTagHelper.cs
+++ b/src/AspNetCore.Honeypot/TagHelpers/HoneypotTimeTagHelper.cs
@@ -32,6 +32,6 @@ public class HoneypotTimeTagHelper : TagHelper
         output.Attributes.Add("name", Options.TimeFieldName);
         output.Attributes.Add("id", Options.TimeFieldName);
         output.Attributes.Add("type", "hidden");
-        output.Content.Append(DateTime.UtcNow.Ticks.ToString());
+        output.Attributes.Add("value", DateTime.UtcNow.Ticks.ToString());
     }
 }


### PR DESCRIPTION
I have found a bug where TimeTagHelper would create a hidden field without a value because Content was used instead of Attributes.